### PR TITLE
Update README to show OS X 10.0+, 68K NeXTSTEP work

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ OpenSTEP 4.0 probably also works given that these all do.
 
 These are attested to be working but are maintained by others.
 
-- Mac OS X Public Beta (PowerPC; `gcc`)
+- Mac OS X Public Beta through 10.1 (PowerPC; Apple `cc` 912+ (actually `gcc` 2.95.2))
+- NeXTSTEP 3.3 (68K; `cc` (actually `gcc` 2.5))
 
 ## Partially working configurations
 


### PR DESCRIPTION
Also fixes compiler binary name on OS X Public Beta and references that old OS X Developer Tools only installs `gcc` as `cc`. 