### PR TITLE
Add support for Solaris

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ These are attested to be working but are maintained by others.
 - Professional MachTen 2.3 (68K; `gcc` 2.7.2.f.1)
 - IRIX 6.5 (SGI MIPS; `gcc` 9.2.0)
 - Haiku R1/beta2 (`x86_64`; `gcc` 8.3.0, requires `-lnetwork`)
+- Solaris 9 (`sparcv9`; `gcc` 2.95.3, requires `-lsocket -lnsl`)
 
 ## Partially working configurations
 

--- a/cryanc.c
+++ b/cryanc.c
@@ -136,7 +136,14 @@
 #if defined(sun) || defined(__sun)
 #if defined(__SVR4) || defined(__svr4__)
 /* Solaris is not officially supported yet */
-#warning compiling for Solaris - NOT YET SUPPORTED
+#warning compiling for Solaris
+#define NOT_POSIX 1
+#include <stdarg.h>
+#include <inttypes.h>
+#ifdef __sparc__
+#define NO_FUNNY_ALIGNMENT 1
+#define __BIG_ENDIAN__ 1
+#endif
 #else
 /* SunOS 4 or OS/MP ... needs a LOT of help! */
 #warning compiling for SunOS 4 and OS/MP


### PR DESCRIPTION
Tested on a Blade 100 running Solaris 9 w/ GCC 2.95.3 from the companion CD.