### PR TITLE
Add support for HP-UX (tested on 11.31 IA-64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ These are attested to be working but are maintained by others.
 - Haiku R1/beta2 (`x86_64`; `gcc` 8.3.0, requires `-lnetwork`)
 - Solaris 9 and 10 (`sparcv9`; `gcc` 2.95.3+, requires `-lsocket -lnsl`)
 - OpenServer 6 (`i386`; `gcc` 7.3.0, requires `-lsocket`)
+- HP-UX 11.31 (`ia64`; `gcc` 4.7.4)
 
 ## Partially working configurations
 

--- a/cryanc.c
+++ b/cryanc.c
@@ -235,6 +235,17 @@ typedef unsigned long long u_int64_t;
 #define NOT_POSIX 1
 #endif
 
+/* HP-UX (tested on 11.31 IA-64) */
+#if defined(__hpux)
+#warning compiling for HP-UX
+#if defined(__ia64)
+#define NO_FUNNY_ALIGNMENT 1
+#else
+#error HP-UX support not tested on other architectures besides ia64
+#error send your patch to fix this - you can help
+#endif
+#endif
+
 /*****************************************************************************
  End of architecture-dependent recipes
  ****************************************************************************/


### PR DESCRIPTION
Got some Itanium hardware, so this was obligatory.

> % uname -a
> HP-UX baal B.11.31 U ia64 1048254743 unlimited-user license