### PR TITLE
Add HP-UX 11.11 on PA-RISC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ These are attested to be working but are maintained by others.
 - Solaris 9 and 10 (`sparcv9`; `gcc` 2.95.3+, requires `-lsocket -lnsl`)
 - OpenServer 6 (`i386`; `gcc` 7.3.0, requires `-lsocket`)
 - HP-UX 11.31 (`ia64`; `cc` A.06.26 and `gcc` 4.7.4)
+- HP-UX 11.11+ (`hppa`; `gcc` 4.7.1)
 
 ## Partially working configurations
 

--- a/carl.c
+++ b/carl.c
@@ -8,7 +8,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/socket.h>
-#if !defined(__AUX__) && (!defined(NS_TARGET_MAJOR) || (NS_TARGET_MAJOR > 3)) && !defined(__MACHTEN_68K__) && !defined(__sun) && !defined(__BEOS__)
+#if !defined(__AUX__) && (!defined(NS_TARGET_MAJOR) || (NS_TARGET_MAJOR > 3)) && !defined(__MACHTEN_68K__) && !defined(__sun) && !defined(__BEOS__) && (!defined(__hppa) && !defined(__hpux))
 #include <sys/select.h>
 #endif
 #include <netinet/in.h>

--- a/cryanc.c
+++ b/cryanc.c
@@ -235,13 +235,14 @@ typedef unsigned long long u_int64_t;
 #define NOT_POSIX 1
 #endif
 
-/* HP-UX (tested on 11.31 IA-64) */
+/* HP-UX (tested on 11.31 IA-64 and 11.11/11.23 PA-RISC) */
 #if defined(__hpux)
 #warning compiling for HP-UX
-#if defined(__ia64)
+#if defined(__ia64) || defined(__hppa)
+#define __BIG_ENDIAN__ 1
 #define NO_FUNNY_ALIGNMENT 1
 #else
-#error HP-UX support not tested on other architectures besides ia64
+#error HP-UX support not tested on other architectures besides ia64 and hppa
 #error send your patch to fix this - you can help
 #endif
 #endif


### PR DESCRIPTION
This seems to mostly work (can grab https://www.google.com, https://www.apple.com, etc.), but running `./carl "https://www.rqsall.com"` results in:

```
tls_consume_stream: No such file or directory
fatal TLS error: -12
```

Not sure what's up with that.