### PR TITLE
Add support for HP-UX 10.20

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ These are attested to be working but are maintained by others.
 - OpenServer 6 (`i386`; `gcc` 7.3.0, requires `-lsocket`)
 - HP-UX 11.31 (`ia64`; `cc` A.06.26 and `gcc` 4.7.4)
 - HP-UX 11.11+ (`hppa`; `gcc` 4.7.1)
+- HP-UX 10.20 (`hppa`; `gcc` 2.95.3, requires `-Doldhpux`)
 
 ## Partially working configurations
 

--- a/cryanc.c
+++ b/cryanc.c
@@ -235,15 +235,24 @@ typedef unsigned long long u_int64_t;
 #define NOT_POSIX 1
 #endif
 
-/* HP-UX (tested on 11.31 IA-64 and 11.11/11.23 PA-RISC) */
+/* HP-UX (tested on 11.31 IA-64 and 10.20/11.11/11.23 PA-RISC) */
 #if defined(__hpux)
-#warning compiling for HP-UX
-#if defined(__ia64) || defined(__hppa)
-#define __BIG_ENDIAN__ 1
-#define NO_FUNNY_ALIGNMENT 1
-#else
+#if !defined(__ia64) && !defined(__hppa)
 #error HP-UX support not tested on other architectures besides ia64 and hppa
 #error send your patch to fix this - you can help
+#endif
+#define __BIG_ENDIAN__ 1
+#define NO_FUNNY_ALIGNMENT 1
+/* HP-UX 10.x and under */
+#if defined(oldhpux)
+#warning compiling for HP-UX before 11
+#define NOT_POSIX 1
+#include <stdarg.h>
+#include <sys/_inttypes.h>
+#include <unistd.h>
+#else
+/* HP-UX 11 and up */
+#warning compiling for current HP-UX
 #endif
 #endif
 
@@ -279,7 +288,7 @@ void __short(void *where, unsigned int index, unsigned short value) {
 
 /* provide definitions if we don't have stdint.h. */
 /* Mach and inttypes.h define these elsewhere. */
-#if !defined(_INTTYPES_H_) && !defined(_INTTYPES_H)
+#if !defined(_INTTYPES_H_) && !defined(_INTTYPES_H) && !defined(__INTTYPES_INCLUDED)
 #if !defined(_MACHTYPES_H_)
 
    typedef signed char             int8_t;


### PR DESCRIPTION
There isn't a good way to detect whether we're on
HP-UX 10 or 11 through preprocessor defined macros,
so users need to define `oldhpux` on pre-11.

Notably, the HP ANSI C compiler's preprocessor (`cpp`), doesn't support `#warning` which causes an error, so I had to use GCC.